### PR TITLE
Revises styling on multiple pages

### DIFF
--- a/application/composer.json
+++ b/application/composer.json
@@ -1,4 +1,6 @@
 {
+    "name": "unheppcat/nor-seasonal-watch-list",
+    "description": "NoR Seasonal Watch List",
     "type": "project",
     "license": "proprietary",
     "minimum-stability": "dev",

--- a/application/config/packages/security.yaml
+++ b/application/config/packages/security.yaml
@@ -41,6 +41,6 @@ security:
         # - { path: ^/profile, roles: ROLE_USER }
         - { path: ^/admin, roles: ROLE_SWL_ADMIN }
         - { path: ^/show, roles: ROLE_SWL_USER }
-        - { path: ^/my, roles: ROLE_SWL_USER }
+        - { path: ^/your, roles: ROLE_SWL_USER }
         - { path: ^/all, roles: ROLE_SWL_USER }
         - { path: ^/election, roles: ROLE_SWL_USER }

--- a/application/config/packages/twig.yaml
+++ b/application/config/packages/twig.yaml
@@ -1,3 +1,5 @@
 twig:
     default_path: '%kernel.project_dir%/templates'
     form_themes: ['bootstrap_4_layout.html.twig']
+    globals:
+        asset_version: '%asset_version%'

--- a/application/config/packages/version.yaml
+++ b/application/config/packages/version.yaml
@@ -1,0 +1,2 @@
+parameters:
+    asset_version: "3"

--- a/application/public/css/navbar-top-fixed.css
+++ b/application/public/css/navbar-top-fixed.css
@@ -3,3 +3,11 @@ body {
     min-height: 75rem;
     padding-top: 4.5rem;
 }
+
+.bg-royal {
+    background-color: #6f42c1;
+}
+
+.text-royal {
+    color: #6f42c1;
+}

--- a/application/public/js/AllWatch.js
+++ b/application/public/js/AllWatch.js
@@ -14,7 +14,15 @@
     $('.all_watch_bar_chart').each( function () {
         const ctx = document.getElementById($(this).attr('id'))
         const data = $(this).data('scores')
-        const maxChartTick = $(this).data('maxcharttick')
+        const maxScore = $(this).data('maxscore')
+        let stepSize, maxChartTick
+        if (maxScore < 6) {
+            stepSize = 1
+            maxChartTick = maxScore + 1
+        } else {
+            stepSize = Math.max(Math.floor(maxScore / 6), 1)
+            maxChartTick = stepSize * (6 + 1)
+        }
         // noinspection JSUnusedLocalSymbols
         const myChart = new Chart(ctx, {
             type: 'horizontalBar',
@@ -30,7 +38,7 @@
             },
             data: {
                 labels: [
-                    'Th8a',
+                    'Th8a should',
                     'Suggested',
                     'Watching',
                     'PTW',
@@ -42,19 +50,22 @@
                     borderColor: '#aaaaaa',
                     borderWidth: 1,
                     backgroundColor: [
-                        '#198754',
-                        '#0d6efd',
-                        '#0d6efd',
-                        '#0dcaf0',
-                        '#6c757d',
-                        '#dc3545'
+                        '#6f42c1',  // purple
+                        '#198754',  // green
+                        '#0d6efd',  // blue
+                        '#0dcaf0',  // cyan
+                        '#6c757d',  // gray-600
+                        '#dc3545'   // red
                     ]
                 }]
             },
             options: {
                 scales: {
                     xAxes: [{
-                        ticks: {stepSize: 1, min: 0, max: maxChartTick}
+                        ticks: {stepSize: stepSize, maxRotation: 0, min: 0, max: maxChartTick}
+                    }],
+                    yAxes: [{
+                        gridLines: {display: false}
                     }]
                 },
                 responsive: false,

--- a/application/src/Controller/AllWatchController.php
+++ b/application/src/Controller/AllWatchController.php
@@ -57,15 +57,15 @@ class AllWatchController extends AbstractController
             $userKeys[$user->getUsername()] = false;
         }
         $data = [];
-        $maxChartTick = 0;
+        $maxScore = 0;
         if ($season !== null) {
             $selectedSeasonId = $season->getId();
             $shows = $showRepository->getShowsForSeason($season);
             $consolidatedShowScores = $showSeasonScoreRepository->getCountsForSeason($season);
             $keyedConsolidatedShowScores = [];
             foreach ($consolidatedShowScores as $consolidatedShowScore) {
-                $maxChartTick = max([
-                    $maxChartTick,
+                $maxScore = max([
+                    $maxScore,
                     $consolidatedShowScore['th8a_count'],
                     $consolidatedShowScore['suggested_count'],
                     $consolidatedShowScore['watching_count'],
@@ -86,10 +86,8 @@ class AllWatchController extends AbstractController
             foreach ($shows as $key => $show) {
                 $showInfo = [
                     'id' => $show->getId(),
-                    'japaneseTitle' => u($show->getJapaneseTitle())->truncate(40, '...', false),
-                    'englishTitle' => u($show->getEnglishTitle())->truncate(40, '...', false),
-                    'fullJapaneseTitle' => u($show->getFullJapaneseTitle())->truncate(40, '...', false),
-                    'coverImage' => $show->getCoverImageMedium(),
+                    'title' => u($show->getAllTitles())->truncate(240, '...', false),
+                    'coverImage' => $show->getCoverImageLarge(),
                 ];
                 $scores = $showSeasonScoreRepository->findAllForSeasonAndShow($season, $show);
                 foreach ($scores as $score) {
@@ -101,7 +99,7 @@ class AllWatchController extends AbstractController
                     'show' => $showInfo,
                     'consolidatedScores' => $keyedConsolidatedShowScores[$show->getId()] ?? null,
                     'scores' => $scores,
-                    'maxChartTick' => $maxChartTick + 1,
+                    'maxScore' => $maxScore,
                 ];
             }
         }

--- a/application/src/Controller/MyVoteController.php
+++ b/application/src/Controller/MyVoteController.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class MyVoteController extends AbstractController
 {
     /**
-     * @Route("/my/vote", name="my_vote")
+     * @Route("/your/vote", name="my_vote")
      * @param Request $request
      * @param EntityManagerInterface $em
      * @param ShowRepository $showRepository

--- a/application/src/Controller/MyWatchController.php
+++ b/application/src/Controller/MyWatchController.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class MyWatchController extends AbstractController
 {
     /**
-     * @Route("/my/watch", name="my_watch_index", options={"expose"=true})
+     * @Route("/your/watch", name="my_watch_index", options={"expose"=true})
      * @param Request $request
      * @param EntityManagerInterface $em
      * @param SeasonRepository $seasonRepository

--- a/application/src/Entity/Show.php
+++ b/application/src/Entity/Show.php
@@ -197,6 +197,33 @@ class Show
         return $this;
     }
 
+    public function getAllTitles(): ?string
+    {
+        $result = [];
+        if (!empty($this->japaneseTitle)) {
+            $result[] = $this->japaneseTitle;
+        }
+        if (!empty($this->fullJapaneseTitle)) {
+            $result[] = $this->fullJapaneseTitle;
+        }
+        if (!empty($this->englishTitle)) {
+            $result[] = $this->englishTitle;
+        }
+        return empty($result) ? null : implode(' / ', $result);
+    }
+
+    public function getAllShortTitles(): ?string
+    {
+        $result = [];
+        if (!empty($this->japaneseTitle)) {
+            $result[] = $this->japaneseTitle;
+        }
+        if (!empty($this->fullJapaneseTitle)) {
+            $result[] = $this->fullJapaneseTitle;
+        }
+        return empty($result) ? null : implode(' / ', $result);
+    }
+
     /**
      * @return Collection|Season[]
      */

--- a/application/templates/all_watch/index.html.twig
+++ b/application/templates/all_watch/index.html.twig
@@ -39,176 +39,202 @@
         </div>
     </div>
 
-    <div class="row mb-2 pb-2 border-bottom border-top pt-2 d-none d-md-flex">
-        <div class="col-md-1"><strong>Show</strong></div>
-        <div class="col-md-2"><strong>&nbsp;</strong></div>
-        <div class="col-md-1"><strong>Should watch</strong></div>
-        <div class="col-md-1"><strong>Should avoid</strong></div>
-        <div class="col-md-1"><strong>Th8a cover</strong></div>
-        <div class="col-md-1"><strong>Total score</strong></div>
-        <div class="col-md-3"><strong>Individual opinions</strong></div>
-        <div class="col-md-2"><strong>Distribution</strong></div>
+    <div class="row mb-2 pb-2 border-bottom border-top pt-2 d-none d-lg-flex">
+        <div class="col-md-2"><strong>Show</strong></div>
+        <div class="col-md-3"><strong>&nbsp;</strong></div>
+        <div class="col-md-3"><strong>Scores</strong></div>
+        <div class="col-md-4"><strong>Recommendations</strong></div>
     </div>
     {% for key, row in data %}
-        <div class="row mb-2 pb-2 border-bottom d-none d-md-flex">
-            <div class="col-md-1">
-                <img class="img" style="max-height:100px;height:100px !important;" src="{{ row.show.coverImage|raw }}" alt="cover image" />
-            </div>
+        <div class="row mb-2 pb-2 border-bottom d-none d-lg-flex">
             <div class="col-md-2">
-                {{ row.show.japaneseTitle }}
-                {% if row.show.japaneseTitle is not empty and row.show.englishTitle is not empty %}/{% endif %}
-                {{ row.show.englishTitle }}
-            </div>
-            <div class="col-md-1">
-                {% if row.consolidatedScores is not empty %}
-                    {{ row.consolidatedScores.yes_count }}
-                {% else %}
-                    0
-                {% endif %}
-            </div>
-            <div class="col-md-1">
-                {% if row.consolidatedScores is not null %}
-                    {{ row.consolidatedScores.no_count }}
-                {% else %}
-                    0
-                {% endif %}
-            </div>
-            <div class="col-md-1">
-                {% if row.consolidatedScores is not null %}
-                    {{ row.consolidatedScores.th8a_count }}
-                {% else %}
-                    0
-                {% endif %}
-            </div>
-            <div class="col-md-1">
-                {% if row.consolidatedScores is not null %}
-                    {% if row.consolidatedScores.score_total is not null %}
-                        {{ row.consolidatedScores.score_total }}
-                    {% else %}
-                        0
-                    {% endif %}
-                {% else %}
-                    0
-                {% endif %}
+                <img class="img-fluid" src="{{ row.show.coverImage|raw }}" alt="cover image" />
             </div>
             <div class="col-md-3">
+                {{ row.show.title }}
+            </div>
+            <div class="col-md-3">
+                <table>
+                    <tbody>
+                    <tr>
+                        <th>Th8a should cover</th>
+                        <td>
+                            {% if row.consolidatedScores is not null %}
+                                {{ row.consolidatedScores.th8a_count }}
+                            {% else %}
+                                0
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Should watch</th>
+                        <td>
+                            {% if row.consolidatedScores is not empty %}
+                                {{ row.consolidatedScores.yes_count }}
+                            {% else %}
+                                0
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Should avoid</th>
+                        <td>
+                            {% if row.consolidatedScores is not null %}
+                                {{ row.consolidatedScores.no_count }}
+                            {% else %}
+                                0
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Total</th>
+                        <td>
+                            {% if row.consolidatedScores is not null %}
+                                {% if row.consolidatedScores.score_total is not null %}
+                                    {{ row.consolidatedScores.score_total }}
+                                {% else %}
+                                    0
+                                {% endif %}
+                            {% else %}
+                                0
+                            {% endif %}
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="col-md-4">
+                {% if row.consolidatedScores.all_count > 0 %}
+                    <canvas width="300"
+                            height="200"
+                            id="bar_{{ row.show.id }}"
+                            class="all_watch_bar_chart"
+                            data-scores="{{ row.consolidatedScores.scores_array }}"
+                            data-maxscore="{{ row.maxScore }}"
+                    ></canvas>
+                {% else %}
+                    &nbsp;
+                {% endif %}
                 {% if row.scores %}
                     {% set foundScores = 0 %}
                     {% for scoreField in row.scores %}
                         {% if users[scoreField.getUser.getUsername] %}
                             {% if scoreField.score %}
                                 {% set foundScores = foundScores + 1 %}
-                                    {{ scoreField.getUser.getUsername }}:
-                                    <span class="text-{{ scoreField.score.getColorValue }}">{{ scoreField.score.getNickname }}</span><br>
                             {% endif %}
                         {% endif %}
                     {% endfor %}
-                    {% if foundScores == 0 %}
-                        <div class="row">
-                            No scores
+                    {% if foundScores > 0 %}
+                        <div>
+                            <a
+                                    class="btn btn-outline-primary mt-3 mb-3"
+                                    data-bs-toggle="collapse"
+                                    href="#collapseRow{{ key }}"
+                                    aria-expanded="false"
+                                    aria-controls="collapseExample"
+                            >Individual</a>
+                        </div>
+                        <div class="collapse" id="collapseRow{{ key }}">
+                            <p>
+                                {% for scoreField in row.scores %}
+                                    {% if users[scoreField.getUser.getUsername] %}
+                                        {% if scoreField.score %}
+                                            {{ scoreField.getUser.getDiscordUsername }}:
+                                            <span class="text-{{ scoreField.score.getColorValue }}">{{ scoreField.score.getNickname }}</span><br>
+                                        {% endif %}
+                                    {% endif %}
+                                {% endfor %}
+                            </p>
                         </div>
                     {% endif %}
-                {% else %}
-                    <div class="row">
-                        <div class="col">No scores</div>
-                    </div>
-                {% endif %}
-
-            </div>
-            <div class="col-md-2">
-                {% if row.consolidatedScores.all_count > 0 %}
-                    <canvas width="150"
-                            height="150"
-                            id="bar_{{ row.show.id }}"
-                            class="all_watch_bar_chart"
-                            data-scores="{{ row.consolidatedScores.scores_array }}"
-                            data-maxcharttick="{{ row.maxChartTick }}"
-                    ></canvas>
-                {% else %}
-                    &nbsp;
                 {% endif %}
             </div>
         </div>
     {% endfor %}
 
-    <div class="row mb-2 pb-2 d-block d-md-none border-bottom">
+    <div class="row mb-2 pb-2 d-block d-lg-none border-bottom">
         <div class="col">&nbsp;</div>
     </div>
 
     {% for key, row in data %}
-        <div class="row mb-2 pb-2 d-block d-md-none">
-            <div class="col-xs-3"><strong>Show</strong></div>
-            <div class="col-xs-3">
-                <img class="img" style="max-height:100px;height:100px !important;" src="{{ row.show.coverImage|raw }}" alt="cover image" />
-            </div>
-            <div class="col-xs-5">
-                {{ row.show.japaneseTitle }} / {{ row.show.englishTitle }}
-            </div>
-        </div>
-        <div class="row mb-2 pb-2 d-block d-md-none">
-            <div class="col-xs-3"><strong>Watch</strong></div>
-            <div class="col-xs-8">
-                {{ row.consolidatedScores.yes_count }}
+        <div class="row mb-2 pb-2 d-block d-lg-none">
+            <div class="col">
+                <strong>Show</strong><br>
+                <span class="float-start">
+                <img class="img-fluid me-2" src="{{ row.show.coverImage|raw }}" alt="cover image" />
+                </span>
+                {{ row.show.title }}
+                <br style="clear:both">
             </div>
         </div>
-        <div class="row mb-2 pb-2 d-block d-md-none">
-            <div class="col-xs-3"><strong>Avoid</strong></div>
-            <div class="col-xs-8">
-                {{ row.consolidatedScores.no_count }}
+        <div class="row mb-2 pb-2 d-block d-lg-none">
+            <div class="col">
+                <table class="table">
+                    <tbody>
+                    <tr>
+                        <td><strong>Th8a</strong></td>
+                        <td><strong>Watch</strong></td>
+                        <td><strong>Avoid</strong></td>
+                        <td><strong>Total</strong></td>
+                    </tr>
+                    <tr>
+                        <td>{{ row.consolidatedScores.th8a_count }}</td>
+                        <td>{{ row.consolidatedScores.yes_count }}</td>
+                        <td>{{ row.consolidatedScores.no_count }}</td>
+                        <td>{{ row.consolidatedScores.score_total }}</td>
+                    </tr>
+                    </tbody>
+                </table>
             </div>
         </div>
-        <div class="row mb-2 pb-2 d-block d-md-none">
-            <div class="col-xs-3"><strong>Th8a</strong></div>
-            <div class="col-xs-8">
-                {{ row.consolidatedScores.th8a_count }}
-            </div>
-        </div>
-        <div class="row mb-2 pb-2 d-block d-md-none">
-            <div class="col-xs-3"><strong>Total</strong></div>
-            <div class="col-xs-8">
-                {{ row.consolidatedScores.score_total }}
-            </div>
-        </div>
-        <div class="row mb-2 pb-2 d-block d-md-none">
-            <div class="col-xs-3"><strong>Scores</strong></div>
-            <div class="col-xs-8">
+        <div class="row mb-3 pb-3 border-bottom d-block d-lg-none">
+            <div class="col">
+                <strong>Recommendations</strong><br>
+                {% if row.consolidatedScores.all_count > 0 %}
+                    <canvas width="300"
+                            height="200"
+                            id="bar_{{ row.show.id }}_narrow"
+                            class="all_watch_bar_chart"
+                            data-scores="{{ row.consolidatedScores.scores_array }}"
+                            data-maxscore="{{ row.maxScore }}"
+                    ></canvas>
+                {% else %}
+                    &nbsp;
+                {% endif %}
+                <br>
                 {% if row.scores %}
                     {% set foundScores = 0 %}
                     {% for scoreField in row.scores %}
                         {% if users[scoreField.getUser.getUsername] %}
                             {% if scoreField.score %}
                                 {% set foundScores = foundScores + 1 %}
-                                {{ scoreField.getUser.getUsername }}:
-                                <span class="text-{{ scoreField.score.getColorValue }}">{{ scoreField.score.getNickname }}</span><br>
                             {% endif %}
                         {% endif %}
                     {% endfor %}
-                    {% if foundScores == 0 %}
-                        <div class="row">
-                            No scores
-                        </div>
-                    {% endif %}
-                {% else %}
-                    <div class="row">
-                        <div class="col">No scores</div>
-                    </div>
                 {% endif %}
-
-            </div>
-        </div>
-        <div class="row mb-3 pb-3 border-bottom d-block d-md-none">
-            <div class="col-xs-3"><strong>Distribution</strong></div>
-            <div class="col-xs-8">
-                {% if row.consolidatedScores.all_count > 0 %}
-                    <canvas width="150"
-                            height="150"
-                            id="bar_{{ row.show.id }}_narrow"
-                            class="all_watch_bar_chart"
-                            data-scores="{{ row.consolidatedScores.scores_array }}"
-                            data-maxcharttick="{{ row.maxChartTick }}"
-                    ></canvas>
-                {% else %}
-                    &nbsp;
+                {% if foundScores > 0 %}
+                    <div>
+                        <a
+                                class="btn btn-outline-primary mt-3 mb-3"
+                                data-bs-toggle="collapse"
+                                href="#collapseRowSmall{{ key }}"
+                                aria-expanded="false"
+                                aria-controls="collapseExample"
+                        >Individual</a>
+                    </div>
+                    <div class="collapse" id="collapseRowSmall{{ key }}">
+                        <p>
+                            {% for scoreField in row.scores %}
+                                {% if users[scoreField.getUser.getUsername] %}
+                                    {% if scoreField.score %}
+                                        {% set foundScores = foundScores + 1 %}
+                                        {{ scoreField.getUser.getDiscordUsername }}:
+                                        <span class="text-{{ scoreField.score.getColorValue }}">{{ scoreField.score.getNickname }}</span><br>
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
+                        </p>
+                    </div>
                 {% endif %}
             </div>
         </div>
@@ -220,6 +246,6 @@
 {% endblock %}
 
 {% block body_javascripts %}
-    <script src="/chart_js/Chart.min.js"></script>
-    <script src="/js/AllWatch.js"></script>
+    <script src="/chart_js/Chart.min.js?v={{ asset_version }}"></script>
+    <script src="/js/AllWatch.js?v={{ asset_version }}"></script>
 {% endblock %}

--- a/application/templates/base.html.twig
+++ b/application/templates/base.html.twig
@@ -4,9 +4,9 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <link href="/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-        <link href="/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">
-        <link href="/css/navbar-top-fixed.css" rel="stylesheet">
+        <link href="/bootstrap/css/bootstrap.min.css?v={{ asset_version }}" rel="stylesheet">
+        <link href="/bootstrap-icons/font/bootstrap-icons.css?v={{ asset_version }}" rel="stylesheet">
+        <link href="/css/navbar-top-fixed.css?v={{ asset_version }}" rel="stylesheet">
 
         <title>{% block title %}Seasonal Watch List{% endblock %}</title>
         {% block stylesheets %}{% endblock %}
@@ -66,13 +66,13 @@
     <div class="container">
         {% block body %}{% endblock %}
     </div>
-    <script src="/js/jquery.min.js"></script>
-    <script src="/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/jquery.min.js?v={{ asset_version }}"></script>
+    <script src="/bootstrap/js/bootstrap.bundle.min.js?v={{ asset_version }}"></script>
 {#    <script src="/js/datatables.min.js"></script>#}
 {#    <script src="/js/jquery.dataTables.min.js"></script>#}
 {#    <script src="/js/dataTables.bootstrap5.min.js"></script>#}
-    <script src="{{ asset('bundles/fosjsrouting/js/router.min.js') }}"></script>
-    <script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
+    <script src="{{ asset('bundles/fosjsrouting/js/router.min.js') }}?v={{ asset_version }}"></script>
+    <script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}&v={{ asset_version }}"></script>
     {% block body_javascripts %}{% endblock %}
     </body>
 </html>

--- a/application/templates/my_vote/index.html.twig
+++ b/application/templates/my_vote/index.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}My Vote{% endblock %}
+{% block title %}Your Vote{% endblock %}
 
 {% block body %}
     <div class="row">
@@ -43,12 +43,10 @@
                 {% for key, row in data %}
                     <tr>
                         <td class="col-md-2 col-xs-2 col-sm-2">
-                            <img src="{{ row.vote.show.getCoverImageMedium|raw }}" alt="cover image" />
+                            <img class="img-fluid" src="{{ row.vote.show.getCoverImageLarge|raw }}" alt="cover image" />
                         </td>
                         <td class="col-md-7 col-xs-6 col-sm-6">
-                            {{ row.vote.show.getJapaneseTitle }}
-                            ({{ row.vote.show.getFullJapaneseTitle }})<br>
-                            {{ row.vote.show.getEnglishTitle }}
+                            {{ row.vote.show.getAllTitles }}
                         </td>
                         <td class="col-md-3 col-xs-4 col-sm-4">
                             {% if row.form %}
@@ -87,5 +85,5 @@
             end: "{{ election.getEndDate|date('c') }}"
         }
     </script>
-    <script src="/js/MyVote.js"></script>
+    <script src="/js/MyVote.js?v={{ asset_version }}"></script>
 {% endblock %}

--- a/application/templates/my_watch/index.html.twig
+++ b/application/templates/my_watch/index.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}My Watch{% endblock %}
+{% block title %}Your Watch{% endblock %}
 
 {% block body %}
     <div class="row mb-5">
@@ -38,20 +38,18 @@
         <div class="col-lg-12">
             <div class="row d-none d-md-flex border-bottom mb-2 pb-2">
                 <div class="col-xs-12 col-md-2">Show</div>
-                <div class="col-xs-12 col-md-7">&nbsp;</div>
-                <div class="col-xs-12 col-md-3">Opinion</div>
+                <div class="col-xs-12 col-md-6">&nbsp;</div>
+                <div class="col-xs-12 col-md-4">Opinion</div>
             </div>
             {% for key, row in data %}
                 <div class="row border-bottom mb-2 pb-md-2 pb-4">
                     <div class="col-xs-12 col-md-2">
-                        <img src="{{ row.score.show.getCoverImageMedium|raw }}" alt="cover image" />
+                        <img class="img-fluid" src="{{ row.score.show.getCoverImageLarge|raw }}" alt="cover image" />
                     </div>
-                    <div class="col-xs-12 col-md-7">
-                        {{ row.score.show.getJapaneseTitle }}
-                        ({{ row.score.show.getFullJapaneseTitle }})<br>
-                        {{ row.score.show.getEnglishTitle }}
+                    <div class="col-xs-12 col-md-6">
+                        {{ row.score.show.getAllTitles }}
                     </div>
-                    <div class="col-xs-12 col-md-3">
+                    <div class="col-xs-12 col-md-4">
                         {% if row.form %}
                             {{ form_start(row.form) }}
                             {{ form_widget(
@@ -91,5 +89,5 @@
 {% endblock %}
 
 {% block body_javascripts %}
-    <script src="/js/MyWatch.js"></script>
+    <script src="/js/MyWatch.js?{{ asset_version }}"></script>
 {% endblock %}


### PR DESCRIPTION
All watches puts individual recommendations in a collapsed container. Fewer columns in the page.
All watches information somewhat denser. Graph formatting improved. Scores put into a vertical table.
Images made to scale and generally larger than before.
/my/* routes changes to /your/* routes to be consistent with the names of those pages.
Purple color added for "Th8a should cover" recommendations.