### PR TITLE
Adds scripts to rebuild the js route cache

### DIFF
--- a/application/scripts/rebuild-js-routes-cache.sh
+++ b/application/scripts/rebuild-js-routes-cache.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Rebuild the application/public/js/fos_js_routes.json file, which
+# caches exposed Symfony routes in a form usable by javascript functions
+# in the browser.
+
+TARGET='public/js/fos_js_routes.json'
+
+# Determine the containing directory of this script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+# Change to the 'application' directory
+cd "$DIR/.." || exit
+
+bin/console fos:js-routing:dump --target="$TARGET"
+
+echo "The file '$TARGET' has been rebuilt."

--- a/deployment/rebuild-javscript-routes-heroku.sh
+++ b/deployment/rebuild-javscript-routes-heroku.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Rebuild the cache of expose Symfony routes for JavaScript use.
+
+heroku run "bin/console fos:js-routing:dump --target=public/js/fos_js_routes.json"


### PR DESCRIPTION
A Symfony plugin maintains a cache file of exposed Symfony routes, which are injected into the browser namespace for use in JavaScript scripts. These scripts make it easier to rebuild that cache of routes when needed.

  * One script for local use
  * One script for use in a Heroku remote instance