### PR TITLE
Adds cross-page memory of the selected season

### DIFF
--- a/application/src/Controller/AllWatchController.php
+++ b/application/src/Controller/AllWatchController.php
@@ -8,6 +8,7 @@ use App\Repository\SeasonRepository;
 use App\Repository\ShowRepository;
 use App\Repository\ShowSeasonScoreRepository;
 use App\Repository\UserRepository;
+use App\Service\SelectedSeasonHelper;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\NonUniqueResultException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -25,32 +26,23 @@ class AllWatchController extends AbstractController
      * @param ShowRepository $showRepository
      * @param ShowSeasonScoreRepository $showSeasonScoreRepository
      * @param UserRepository $userRepository
+     * @param SelectedSeasonHelper $selectedSeasonHelper
      * @return Response
+     * @throws Exception
      * @throws NonUniqueResultException
      * @throws \Doctrine\DBAL\Driver\Exception
-     * @throws Exception
      */
     public function index(
         Request $request,
         SeasonRepository $seasonRepository,
         ShowRepository $showRepository,
         ShowSeasonScoreRepository $showSeasonScoreRepository,
-        UserRepository $userRepository
+        UserRepository $userRepository,
+        SelectedSeasonHelper $selectedSeasonHelper
     ): Response {
+        $selectedSeasonId = null;
         $seasons = $seasonRepository->getAllInRankOrder();
-        $selectedSeasonId = $request->get('season');
-
-//        /** @var User $user */
-//        $user = $this->getUser();
-//        $data = [];
-        if ($selectedSeasonId === null) {
-            $season = $seasonRepository->getSeasonForDate();
-            if ($season === null) {
-                $season = $seasonRepository->getFirstSeason();
-            }
-        } else {
-            $season = $seasonRepository->find($selectedSeasonId);
-        }
+        $season = $selectedSeasonHelper->getSelectedSeason($request);
         $users = $userRepository->getAllSorted();
         $userKeys = [];
         foreach ($users as $user) {

--- a/application/src/Controller/MyWatchController.php
+++ b/application/src/Controller/MyWatchController.php
@@ -10,6 +10,7 @@ use App\Form\ShowSeasonScoreType;
 use App\Repository\SeasonRepository;
 use App\Repository\ShowRepository;
 use App\Repository\ShowSeasonScoreRepository;
+use App\Service\SelectedSeasonHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -26,6 +27,7 @@ class MyWatchController extends AbstractController
      * @param SeasonRepository $seasonRepository
      * @param ShowRepository $showRepository
      * @param ShowSeasonScoreRepository $showSeasonScoreRepository
+     * @param SelectedSeasonHelper $selectedSeasonHelper
      * @return Response
      * @throws NonUniqueResultException
      */
@@ -34,22 +36,18 @@ class MyWatchController extends AbstractController
         EntityManagerInterface $em,
         SeasonRepository $seasonRepository,
         ShowRepository $showRepository,
-        ShowSeasonScoreRepository $showSeasonScoreRepository
+        ShowSeasonScoreRepository $showSeasonScoreRepository,
+        SelectedSeasonHelper $selectedSeasonHelper
     ): Response {
         $seasons = $seasonRepository->getAllInRankOrder();
-        $selectedSeasonId = $request->get('season');
 
         /** @var User $user */
         $user = $this->getUser();
         $data = [];
-        if ($selectedSeasonId === null) {
-            $season = $seasonRepository->getSeasonForDate();
-            if ($season === null) {
-                $season = $seasonRepository->getFirstSeason();
-            }
-        } else {
-            $season = $seasonRepository->find($selectedSeasonId);
-        }
+        $selectedSeasonId = null;
+
+        $season = $selectedSeasonHelper->getSelectedSeason($request);
+
         if ($season !== null) {
             $selectedSeasonId = $season->getId();
             $shows = $showRepository->getShowsForSeason($season);
@@ -92,4 +90,5 @@ class MyWatchController extends AbstractController
             'data' => $data,
         ]);
     }
+
 }

--- a/application/src/Service/SelectedSeasonHelper.php
+++ b/application/src/Service/SelectedSeasonHelper.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Season;
+use App\Repository\SeasonRepository;
+use Doctrine\ORM\NonUniqueResultException;
+use Symfony\Component\HttpFoundation\Request;
+
+final class SelectedSeasonHelper
+{
+    /**
+     * @var SeasonRepository
+     */
+    private SeasonRepository $seasonRepository;
+
+    /**
+     * SelectedSeasonHelper constructor.
+     * @param SeasonRepository $seasonRepository
+     */
+    public function __construct(SeasonRepository $seasonRepository)
+    {
+        $this->seasonRepository = $seasonRepository;
+    }
+
+    /**
+     * @param Request $request
+     * @return Season|null
+     * @throws NonUniqueResultException
+     */
+    public function getSelectedSeason(Request $request): ?Season
+    {
+        $selectedSeasonId = $request->get('season');
+        if ($selectedSeasonId === null) {
+            $selectedSeasonId = $request->getSession()->get('selectedSeasonId', null);
+        }
+        if ($selectedSeasonId === null) {
+            $season = $this->seasonRepository->getSeasonForDate();
+            if ($season === null) {
+                $season = $this->seasonRepository->getFirstSeason();
+            }
+        } else {
+            $season = $this->seasonRepository->find($selectedSeasonId);
+        }
+        $request->getSession()->set('selectedSeasonId', $selectedSeasonId);
+        return $season;
+    }
+
+}


### PR DESCRIPTION
When a non-default season is selected, that choice is now stored in the session. That choice is now applied whenever a season-specific page is loaded, whenever no other explicit season is asked for (through the URL).