### PR TITLE
Fixes wrong connections between radio buttons and labels

### DIFF
--- a/application/src/Controller/MyWatchController.php
+++ b/application/src/Controller/MyWatchController.php
@@ -14,6 +14,7 @@ use App\Service\SelectedSeasonHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -28,6 +29,7 @@ class MyWatchController extends AbstractController
      * @param ShowRepository $showRepository
      * @param ShowSeasonScoreRepository $showSeasonScoreRepository
      * @param SelectedSeasonHelper $selectedSeasonHelper
+     * @param FormFactoryInterface $formFactory
      * @return Response
      * @throws NonUniqueResultException
      */
@@ -37,7 +39,8 @@ class MyWatchController extends AbstractController
         SeasonRepository $seasonRepository,
         ShowRepository $showRepository,
         ShowSeasonScoreRepository $showSeasonScoreRepository,
-        SelectedSeasonHelper $selectedSeasonHelper
+        SelectedSeasonHelper $selectedSeasonHelper,
+        FormFactoryInterface $formFactory
     ): Response {
         $seasons = $seasonRepository->getAllInRankOrder();
 
@@ -65,7 +68,8 @@ class MyWatchController extends AbstractController
                     $em->persist($score);
                     $em->flush();
                 }
-                $form = $this->createForm(
+                $form = $formFactory->createNamed(
+                    'show_season_score_' . $key,
                     ShowSeasonScoreType::class,
                     $score,
                     [
@@ -75,7 +79,13 @@ class MyWatchController extends AbstractController
                         ],
                         'show_score_only' => true,
                         'form_key' => $key,
-                        'action' => $this->generateUrl('admin_show_season_score_edit', ['id' => $score->getId()])
+                        'action' => $this->generateUrl(
+                            'admin_show_season_score_edit',
+                            [
+                                'id' => $score->getId(),
+                                'key' => $key
+                            ]
+                        )
                     ]
                 );
                 $data[] = ['score' => $score, 'form' => $form->createView()];

--- a/application/src/Controller/ShowSeasonScoreController.php
+++ b/application/src/Controller/ShowSeasonScoreController.php
@@ -7,6 +7,7 @@ use App\Entity\User;
 use App\Form\ShowSeasonScoreType;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,13 +20,17 @@ use Symfony\Component\Routing\Annotation\Route;
 class ShowSeasonScoreController extends AbstractController
 {
     /**
-     * @Route("/{id}/edit", name="admin_show_season_score_edit", methods={"GET","POST"})
+     * @Route("/{id}/edit/{key}", name="admin_show_season_score_edit", methods={"GET","POST"})
      * @param Request $request
      * @param ShowSeasonScore $showSeasonScore
+     * @param FormFactoryInterface $formFactory
      * @return Response
      */
-    public function edit(Request $request, ShowSeasonScore $showSeasonScore): Response
-    {
+    public function edit(
+        Request $request,
+        ShowSeasonScore $showSeasonScore,
+        FormFactoryInterface $formFactory
+    ): Response {
         try {
             /** @var User $user */
             $user = $this->getUser();
@@ -36,7 +41,10 @@ class ShowSeasonScoreController extends AbstractController
                 return new JsonResponse(['data' => ['status' => 'permission_denied']], Response::HTTP_FORBIDDEN);
             }
 
-            $form = $this->createForm(
+            $key = $request->get('key');
+
+            $form = $formFactory->createNamed(
+                'show_season_score_' . $key,
                 ShowSeasonScoreType::class,
                 $showSeasonScore,
                 [


### PR DESCRIPTION
The page has multiple copies of the same form. All forms originally had the same name, which broke the 'label for' connection. (All labels were attached to the first form.) This change gives each form on the page a unique name.