### PR TITLE
Fixes nickname set bug

### DIFF
--- a/application/src/Security/AppDiscordAuthenticator.php
+++ b/application/src/Security/AppDiscordAuthenticator.php
@@ -125,9 +125,7 @@ class AppDiscordAuthenticator extends SocialAuthenticator // AbstractGuardAuthen
         }
         try {
             $nickname = $this->getDiscordNickname($credentials->getToken(), $discordId);
-            if ($nickname !== null) {
-                $existingUser->setDisplayName($nickname);
-            }
+            $existingUser->setDisplayName($nickname);
         } catch (GuzzleException|Exception $e) {
             $user->setDisplayName(null);
         }


### PR DESCRIPTION
When the nickname returned from Discord was null, app did not clear out the previously stored nickname (if any). So no way to unset the changed nickname to the original Discord username.