### PR TITLE
CORS: Allow the exact header that ApiKeyAuthenticator uses

### DIFF
--- a/application/config/packages/nelmio_cors.yaml
+++ b/application/config/packages/nelmio_cors.yaml
@@ -12,6 +12,6 @@ nelmio_cors:
             allow_origin: ['*']
             expose_headers: []
             allow_methods: ['GET', 'OPTIONS']
-            allow_headers: ['Content-Type', 'X-AUTH_TOKEN']
+            allow_headers: ['Content-Type', 'X-AUTH-TOKEN']
         '^/':
             origin_regex: true


### PR DESCRIPTION
When you try to use the `X-AUTH-TOKEN` header for API key authentication, CORS preflight request fails with a 400 error.

Tried these out in an [Observable](https://observablehq.com/) notebook:

```js
d3 = require("d3@6")

d3.json("https://.../api/v1/seasons", {
  headers: {
    "X-AUTH-TOKEN": "..."
  }
}) // => 400 Bad Request (in response to the OPTIONS preflight request)

d3.json("https://.../api/v1/seasons", {
  headers: {
    "X-AUTH_TOKEN": "..."
  }
}) // => 401 Unauthorized (preflight request passes, but the main request doesn't pass the authenticator)
```

This PR changes the `Access-Control-Allow-Headers` list to include the kebab-case header name (`X-AUTH-TOKEN`) instead of the kebab-snake-case header name (`X-AUTH_TOKEN`).