### PR TITLE
Vertically align Voted/Not Voted badge

### DIFF
--- a/application/templates/my_vote/election_list.html.twig
+++ b/application/templates/my_vote/election_list.html.twig
@@ -14,7 +14,7 @@
 
             <a href="{{ path('my_vote_ballot', {'id': election.id}) }}"
                class="list-group-item list-group-item-action">
-                <div class="d-flex w-100 justify-content-between">
+                <div class="d-flex w-100 justify-content-between align-items-center">
                     <h5 class="mb-1">
                         {% if election.title %}
                             {{ election.title }}


### PR DESCRIPTION
I have not tested this locally - just tweaked Bootstrap classes in my browser. 

<img width="2413" height="1432" alt="before/after" src="https://github.com/user-attachments/assets/0eb1e6e7-b91b-44fe-b209-cb72f7556847" />

First election: no `align-items-center`
Second election: with `align-items-center` applied